### PR TITLE
Skip nexus staging of vaadin com demos

### DIFF
--- a/vaadin-cookie-consent-flow-vaadincom-demo/pom.xml
+++ b/vaadin-cookie-consent-flow-vaadincom-demo/pom.xml
@@ -87,6 +87,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
They are deployed in a separate build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-cookie-consent-flow/29)
<!-- Reviewable:end -->
