### PR TITLE
Dependency moved to org.webjars.bowergithub.osano

### DIFF
--- a/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow/pom.xml
@@ -40,7 +40,7 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.webjars.bowergithub.insites</groupId>
+            <groupId>org.webjars.bowergithub.osano</groupId>
             <artifactId>cookieconsent</artifactId>
             <version>3.1.0</version>
         </dependency>

--- a/vaadin-cookie-consent-flow/pom.xml
+++ b/vaadin-cookie-consent-flow/pom.xml
@@ -33,6 +33,12 @@
             <groupId>com.vaadin.webjar</groupId>
             <artifactId>vaadin-cookie-consent</artifactId>
             <version>1.1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.osano</groupId>
+                    <artifactId>cookieconsent</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
@@ -40,7 +46,7 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.webjars.bowergithub.osano</groupId>
+            <groupId>org.webjars.bowergithub.insites</groupId>
             <artifactId>cookieconsent</artifactId>
             <version>3.1.0</version>
         </dependency>


### PR DESCRIPTION
It used to be org.webjars.bowergithub.insites, but was moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-cookie-consent-flow/75)
<!-- Reviewable:end -->
